### PR TITLE
encapsulates render function, add canonicalize url

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CXX_FLAGS "--std=c++11 -ggdb3 ${CMAKE_CXX_FLAGS} ${Qt5Widgets_EXECUTAB
 include_directories(${Qt5Core_INCLUDE_DIRS})
 
 # Boost
-FIND_PACKAGE(Boost 1.54.0 COMPONENTS system thread coroutine context REQUIRED)
+FIND_PACKAGE(Boost 1.54.0 COMPONENTS system thread coroutine context filesystem REQUIRED)
 message("Boost include dir: ${Boost_INCLUDE_DIR}")
 message("Boost libraries: ${Boost_LIBRARIES}")
 INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})

--- a/modules/portal/http_utils.cc
+++ b/modules/portal/http_utils.cc
@@ -1,0 +1,107 @@
+#include "http_utils.h"
+
+using namespace std;
+
+namespace portal {
+
+    // Auxiliary methods
+    void tokenize(string url, const char* delimiter, vector<string> &tokens)
+    {
+        assert(url.length() > 0);
+        assert(delimiter);
+
+        boost::char_separator<char> sep(delimiter);
+        boost::tokenizer<boost::char_separator<char> > tok(url, sep);
+        for(auto it = tok.begin(); it != tok.end(); ++it){
+            tokens.push_back(string(*it));
+        }
+    }
+
+    // API
+    string canonicalize_get_url(shared_ptr<HttpServer::Request> req)
+    {
+        assert(req);
+
+        string url = req->path;
+        vector<string> tokens;
+        vector<string> canonicalized;
+        tokenize(url, "/", tokens);
+
+        // process tokens
+        for (auto token : tokens) {
+#if 0
+            std::cout << "Token: " << token << std::endl;
+#endif
+            if (token == string("..")) {
+                if (canonicalized.size() == 0) throw 400; // bad request
+                canonicalized.pop_back();
+            }
+            else if (token == string(".")) {
+                // do nothing
+            }
+            else {
+                canonicalized.push_back(token);
+            }
+        }
+
+        string ret = boost::algorithm::join(canonicalized, "/");
+        return string("/") + ret;
+    }
+
+    void render(HttpServer::Response& response, string filename) 
+    {
+        string webroot(pref::instance()->get_webroot());
+
+        filename = webroot + filename;
+        if (boost::filesystem::is_directory(filename)) 
+            filename += string("/index.html");
+
+		ifstream ifs;
+        ifs.open(filename, ifstream::in);
+
+        // consider to make it more flexible, one should retrieve 404 page url 
+        // by configuration
+        if (!ifs.good()) ifs.open(webroot + string("/404.html"), ifstream::in);
+        // assert(ifs.good());
+
+        ifs.seekg(0, ios::end);
+        size_t length=ifs.tellg();
+
+        ifs.seekg(0, ios::beg);
+
+        response << "HTTP/1.1 200 OK\r\nContent-Length: "
+            << length
+            << "\r\n\r\n";
+
+        // read and send 128 KB at a time if file-size>buffer_size
+        size_t buffer_size=131072;
+        if (length > buffer_size) {
+            vector<char> buffer(buffer_size);
+            size_t read_length;
+            while ((read_length=ifs.read(&buffer[0], buffer_size).gcount()) > 0) {
+                response.stream.write(&buffer[0], read_length);
+                response << HttpServer::flush;
+            }
+        }
+        else
+            response << ifs.rdbuf();
+
+        ifs.close();
+    }
+
+    void render_bad_request(HttpServer::Response& response)
+    {
+        render(response, "400.html");
+    }
+
+    void render_not_found(HttpServer::Response& response)
+    {
+        render(response, "404.html");
+    }
+
+    void render_internal_server_error(HttpServer::Response& response)
+    {
+        render(response, "500.html");
+    }
+
+};

--- a/modules/portal/http_utils.h
+++ b/modules/portal/http_utils.h
@@ -1,0 +1,39 @@
+#include <QDebug> 
+#include <vector>
+#include <string>
+#include <fstream>
+#include <iostream>
+
+#include <boost/tokenizer.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string/join.hpp>
+
+#include <server_http.hpp>
+#include <pref.h>
+
+#ifndef PORTAL_HTTP_UTILS_H
+#define PORTAL_PORTAL_HTTP_UTILS_H
+
+using namespace std;
+
+namespace portal {
+
+	typedef SimpleWeb::Server<SimpleWeb::HTTP> HttpServer;
+
+    // transform get request path into canonicalized path, 
+    // i.e. remove all "..", "." characters
+    // This method will throw 400 error if trying to leave webroot
+    string canonicalize_get_url(shared_ptr<HttpServer::Request> req);
+
+    // render static page with header
+    void render(HttpServer::Response& response, string filename);
+
+    void render_bad_request(HttpServer::Response& response);
+
+    void render_not_found(HttpServer::Response& response);
+
+    void render_internal_server_error(HttpServer::Response& response);
+
+};
+
+#endif /* end of include guard: PORTAL_HTTP_UTILS_H */

--- a/webroot/400.html
+++ b/webroot/400.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Bad Request 400</title>
+  </head>
+  <body>
+    <h1>Bad Request Error Code 400</h1>
+  </body>
+</html>

--- a/webroot/404.html
+++ b/webroot/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Not Found 404</title>
+  </head>
+  <body>
+    <h1>Not Found Error Code 404</h1>
+  </body>
+</html>

--- a/webroot/500.html
+++ b/webroot/500.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Internal Server Error 500</title>
+  </head>
+  <body>
+    <h1>Internal Server Error 500</h1>
+  </body>
+</html>


### PR DESCRIPTION
1. adding canonicalize_get_url() method, which is a token-based method to remove irregularities in url, such as "..", ".". When encoutering "..", it will pop up the previous directory. When encountering ".", simply remove it.
2. adding encapsulation with render method. It is a method for serving static page, but encapsulated for future development.
