### PR TITLE
Encapsulate make_response_header; Add a method to process json data

### DIFF
--- a/modules/portal/http_utils.cc
+++ b/modules/portal/http_utils.cc
@@ -17,6 +17,8 @@ namespace portal {
         }
     }
 
+    // API
+
     void make_response_header(HttpServer::Response& response, string status, map<string, string> &header_info) 
     {
         response << "HTTP/1.1 " << status << "\r\n";
@@ -26,7 +28,6 @@ namespace portal {
         response << "\r\n";
     }
 
-    // API
     string canonicalize_get_url(shared_ptr<HttpServer::Request> req)
     {
         assert(req);
@@ -83,6 +84,7 @@ namespace portal {
         ifs.seekg(0, ios::beg);
 
         map<string, string> header_info = {
+            { "class",          "http_file_fetch" },
             { "Content-Length", to_string(length) }
         };
         string status = notFound ? "404 NOT FOUND" : "200 OK";

--- a/modules/portal/http_utils.h
+++ b/modules/portal/http_utils.h
@@ -1,4 +1,5 @@
 #include <QDebug> 
+#include <map>
 #include <vector>
 #include <string>
 #include <fstream>

--- a/modules/portal/http_utils.h
+++ b/modules/portal/http_utils.h
@@ -26,6 +26,9 @@ namespace portal {
     // This method will throw 400 error if trying to leave webroot
     string canonicalize_get_url(shared_ptr<HttpServer::Request> req);
 
+    // fill in fields for http response header
+    void make_response_header(HttpServer::Response& response, string status, map<string, string> &header_info);
+
     // render static page with header
     void render(HttpServer::Response& response, string filename);
 

--- a/scripts/post_request.py
+++ b/scripts/post_request.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python2
+
+import json
+import requests
+
+payload = { \
+    "class": "json",
+    "key1" : "value1",
+    "key2" : "value2",
+}
+
+url = "http://localhost:8080/"
+
+response = requests.get(url)
+print "GET status:", response.status_code
+
+response = requests.post(url, data=json.dumps(payload))
+print "POST status:", response.status_code
+print "POST content:", response.text


### PR DESCRIPTION
Same as the title.

make_response_header(..) will probably be frequently used, so I encapsulated it.

add a post request process method for accepting json in server to solve #25 (require more processing in back end, such as translating json to parcel).
